### PR TITLE
reduce texture sampler state changes in metal

### DIFF
--- a/src/mbgl/mtl/texture2d.cpp
+++ b/src/mbgl/mtl/texture2d.cpp
@@ -21,6 +21,11 @@ Texture2D::~Texture2D() {
 }
 
 gfx::Texture2D& Texture2D::setSamplerConfiguration(const SamplerState& samplerState_) noexcept {
+    if (samplerState.filter == samplerState_.filter && samplerState.wrapU == samplerState_.wrapU &&
+        samplerState.wrapV == samplerState_.wrapV) {
+        return *this;
+    }
+
     samplerState = samplerState_;
     samplerStateDirty = true;
     return *this;
@@ -216,6 +221,8 @@ void Texture2D::updateSamplerConfiguration() noexcept {
                                            ? MTL::SamplerAddressModeClampToEdge
                                            : MTL::SamplerAddressModeRepeat);
     metalSamplerState = context.createMetalSamplerState(samplerDescriptor);
+
+    samplerStateDirty = false;
 }
 
 void Texture2D::bind(RenderPass& renderPass, int32_t location) noexcept {


### PR DESCRIPTION
- Check if the sampler state changes in `setSamplerConfiguration` and
if they are the same we return the same object and create a new one
if they are different.
- Set `samplerStateDirty` at the end of `updateSamplerConfiguration`
to avoid calling `updateSamplerConfiguration` for every texture
on every frame.
